### PR TITLE
Refactor how fields are queried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+breaking change for fields
+
 # 0.6.0 - 28 July 2020
 
 - Fix: broken dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
-breaking change for fields
+# 0.7.0 - 28 August 2020
+
+- Refactor interface for requesting custom response fields
+
+## Breaking Change
+
+Heads up, the argument to request fields was previously called `tweet_fields`; it is now called `fields`. 
+
+```ruby
+api.get_tweet(id: '123455683780', fields: requested_fields)
+```
+
+The `fields` parameter now supports multiple different data types (instead of just Tweet attributes). So for example, to request the URL of an embedded media item:
+
+```ruby
+requested_fields = { tweet: %w[id username], media: %w[url] }
+
+api.get_tweet(id: my_id, fields: requested_fields)
+```
 
 # 0.6.0 - 28 July 2020
 

--- a/README.md
+++ b/README.md
@@ -32,14 +32,13 @@ api.get_tweet(id: '1234671272602193920')
 
 #### Specifying which fields to include in the response
 
-By default, the gem requests the 'default' fields for each entity. See the [API Reference](https://developer.twitter.com/en/docs/labs/tweets-and-users/api-reference) for available fields. One can customize the response payload like so:
+By default, the gem requests the 'default' fields for each entity. See the [API Reference](https://developer.twitter.com/en/docs/labs/tweets-and-users/api-reference) for available fields. One can customize the response payload, depending on the requested resource.
 
+For example, to request the URL of a Tweet's embedded media item:
 ```ruby
-my_fields = %w[id author_id created_at text]
+requested_fields = { tweet: %w[id username], media: %w[url] }
 
-api.get_tweet(id: '1235508591232090112', tweet_fields: my_fields)
-
->> {"author_id"=>"229708614", "created_at"=>"2020-03-05T10:12:57.000Z", "id"=>"1235508591232090112", "text"=>"Hot take: coronavirus will not boost remote work in the long run because spur-of-the-moment work-from-home for in-person companies is likely to be a shitshow."}
+api.get_tweet(id: my_id, fields: requested_fields)
 ```
 
 #### API Errors

--- a/lib/twitter_labs_api/resources/tweet.rb
+++ b/lib/twitter_labs_api/resources/tweet.rb
@@ -6,7 +6,9 @@ module TwitterLabsAPI
 
       # Returns a variety of information about a single Tweet specified by the requested ID.
       # @param [String] :id the ID of the requested Tweet
-      # @param [Array<String>] :tweet_fields (["id", "author_id", "created_at", "lang", "public_metrics"]) the list of fields to retrieve for the given tweet
+      # @param [Hash] :fields a hash for fields to include in the response payload; 
+      #
+      #     e.g.: { tweet: %w[id username], media: %w[url] }
       # @return Hash an object with requested tweet fields
       def get_tweet(id:, fields: DEFAULT_FIELDS)
         url = "https://api.twitter.com/labs/2/tweets/#{id}"
@@ -17,7 +19,9 @@ module TwitterLabsAPI
 
       # Returns a variety of information about the Tweet specified by the requested ID or list of IDs.
       # @param [Array<String>] :ids the collection of requested Tweet IDs
-      # @param [Array<String>] :tweet_fields (["id", "author_id", "created_at", "lang", "public_metrics"]) the list of fields to retrieve for the given tweet
+      # @param [Hash] :fields a hash for fields to include in the response payload; 
+      #
+      #     e.g.: { tweet: %w[id username], media: %w[url] }
       # @return [Array<Hash>] of tweet objects with the requested tweet fields
       def get_tweets(ids:, fields: DEFAULT_FIELDS)
         url = 'https://api.twitter.com/labs/2/tweets'
@@ -38,7 +42,10 @@ module TwitterLabsAPI
 
       # The Labs recent search endpoint returns Tweets from the last 7 days that match a search query.
       # @param [String] :query the search query
-      # @param [Array<String>] :tweet_fields (["id", "author_id", "created_at", "lang", "public_metrics"]) the list of fields to retrieve for the given tweet
+      # @param [Hash] :fields a hash for fields to include in the response payload; 
+      #
+      #     e.g.: { tweet: %w[id username], media: %w[url] }
+      # @return [Array<Hash>] of tweet objects with the requested tweet fields
       def search(query:, fields: DEFAULT_FIELDS)
         url = 'https://api.twitter.com/labs/2/tweets/search'
         params = ParamsService.from_fields(fields)

--- a/lib/twitter_labs_api/resources/tweet.rb
+++ b/lib/twitter_labs_api/resources/tweet.rb
@@ -2,16 +2,15 @@ module TwitterLabsAPI
   module Resources
     module Tweet
       DEFAULT_TWEET_FIELDS = %w[id author_id created_at lang public_metrics].freeze
+      DEFAULT_FIELDS = { tweet: DEFAULT_TWEET_FIELDS }.freeze
 
       # Returns a variety of information about a single Tweet specified by the requested ID.
       # @param [String] :id the ID of the requested Tweet
       # @param [Array<String>] :tweet_fields (["id", "author_id", "created_at", "lang", "public_metrics"]) the list of fields to retrieve for the given tweet
       # @return Hash an object with requested tweet fields
-      def get_tweet(id:, tweet_fields: DEFAULT_TWEET_FIELDS)
+      def get_tweet(id:, fields: DEFAULT_FIELDS)
         url = "https://api.twitter.com/labs/2/tweets/#{id}"
-        params = {
-          'tweet.fields' => tweet_fields.join(',')
-        }.compact
+        params = ParamsService.from_fields(fields)
 
         make_request(url: url, params: params)
       end
@@ -20,12 +19,10 @@ module TwitterLabsAPI
       # @param [Array<String>] :ids the collection of requested Tweet IDs
       # @param [Array<String>] :tweet_fields (["id", "author_id", "created_at", "lang", "public_metrics"]) the list of fields to retrieve for the given tweet
       # @return [Array<Hash>] of tweet objects with the requested tweet fields
-      def get_tweets(ids:, tweet_fields: DEFAULT_TWEET_FIELDS)
+      def get_tweets(ids:, fields: DEFAULT_FIELDS)
         url = 'https://api.twitter.com/labs/2/tweets'
-        params = {
-          'ids' => ids.join(','),
-          'tweet.fields' => tweet_fields.join(',')
-        }.compact
+        params = ParamsService.from_fields(fields)
+        params.merge!({ ids: ids.join(',') })
 
         make_request(url: url, params: params, is_collection: true)
       end
@@ -42,13 +39,10 @@ module TwitterLabsAPI
       # The Labs recent search endpoint returns Tweets from the last 7 days that match a search query.
       # @param [String] :query the search query
       # @param [Array<String>] :tweet_fields (["id", "author_id", "created_at", "lang", "public_metrics"]) the list of fields to retrieve for the given tweet
-      # @param [Array<String>] :tweet_fields (["id", "author_id", "created_at", "lang", "public_metrics"]) the list of fields to retrieve for the given tweet
-      def search(query:, tweet_fields: DEFAULT_TWEET_FIELDS)
-        url = "https://api.twitter.com/labs/2/tweets/search"
-        params = {
-          'query' => query,
-          'tweet.fields' => tweet_fields.join(',')
-        }.compact
+      def search(query:, fields: DEFAULT_FIELDS)
+        url = 'https://api.twitter.com/labs/2/tweets/search'
+        params = ParamsService.from_fields(fields)
+        params.merge!({ query: query })
 
         make_request(url: url, params: params, is_collection: true)
       end

--- a/lib/twitter_labs_api/resources/user.rb
+++ b/lib/twitter_labs_api/resources/user.rb
@@ -2,44 +2,45 @@ module TwitterLabsAPI
   module Resources
     module User
       DEFAULT_USER_FIELDS = %w[id name username].freeze
+      DEFAULT_FIELDS = { user: DEFAULT_USER_FIELDS }.freeze
 
       # Returns a variety of information about a single more user specified by the requested ID.
       # @param [String] :id the ID of the requested User
-      # @param [Array<String>] :user_fields (["name", "username"]) the list of fields to retrieve for the given User
+      # @param [Hash] :fields  a hash for fields to include in the response payload; 
+      #
+      #  e.g.: { user: %w[id name username] }
       # @return Hash an object with requested user fields
-      def get_user(id:, user_fields: DEFAULT_USER_FIELDS)
+      def get_user(id:, fields: DEFAULT_FIELDS)
         url = "https://api.twitter.com/labs/2/users/#{id}"
-        params = {
-          'user.fields' => user_fields.join(',')
-        }.compact
+        params = ParamsService.from_fields(fields)
 
         make_request(url: url, params: params)
       end
 
       # Returns a variety of information about one or more Users specified by the requested IDs.
       # @param [Array<String>] :ids the collection of requested User IDs
-      # @param [Array<String>] :user_fields (["name", "username"]) the list of fields to retrieve for the given User
+      # @param [Hash] :fields  a hash for fields to include in the response payload; 
+      #
+      #  e.g.: { user: %w[id name username] }
       # @return [Array<Hash>] of user objects with the requested user fields
-      def get_users(ids:, user_fields: DEFAULT_USER_FIELDS)
+      def get_users(ids:, fields: DEFAULT_FIELDS)
         url = 'https://api.twitter.com/labs/2/users'
-        params = {
-          'ids' => ids.join(','),
-          'user.fields' => user_fields.join(',')
-        }.compact
+        params = ParamsService.from_fields(fields)
+        params.merge!({ ids: ids.join(',') })
 
         make_request(url: url, params: params, is_collection: true)
       end
 
       # Returns a variety of information about one or more Users specified by the requested usernames.
       # @param [Array<String>] :usernames the collection of requested Usernames
-      # @param [Array<String>] :user_fields (["name", "username"]) the list of fields to retrieve for the given User
+      # @param [Hash] :fields  a hash for fields to include in the response payload; 
+      #
+      #  e.g.: { user: %w[id name username] }
       # @return [Array<Hash>] of user objects with the requested user fields
-      def get_users_by_usernames(usernames:, user_fields: DEFAULT_USER_FIELDS)
+      def get_users_by_usernames(usernames:, fields: DEFAULT_FIELDS)
         url = 'https://api.twitter.com/labs/2/users/by'
-        params = {
-          'usernames' => usernames.join(','),
-          'user.fields' => user_fields.join(',')
-        }.compact
+        params = ParamsService.from_fields(fields)
+        params.merge!({ usernames: usernames.join(',') })
 
         make_request(url: url, params: params, is_collection: true)
       end

--- a/lib/twitter_labs_api/services/params_service.rb
+++ b/lib/twitter_labs_api/services/params_service.rb
@@ -1,0 +1,15 @@
+class ParamsService
+  # Convert user-passed fields hash to query params
+  # @param [Hash] :fields A hash of requested fields; see API Reference for details
+  # @return [Hash] A hash of query params for consumption by API client
+  # @example
+  #     input: { tweet: %w[id username], media: ['url'] }
+  #     output: { 'tweet.fields' => 'id,username', 'media.fields' => 'url }
+  def self.from_fields(fields)
+    fields.keys.inject({}) do |memo, key|
+      memo["#{key}.fields"] = fields[key].join(',')
+
+      memo
+    end
+  end
+end

--- a/spec/lib/resources/tweet_spec.rb
+++ b/spec/lib/resources/tweet_spec.rb
@@ -3,15 +3,22 @@ describe TwitterLabsAPI::Resources::Tweet do
 
   describe '#get_tweet' do
     let(:endpoint_stub) do
-      stub_request(:get, 'https://api.twitter.com/labs/2/tweets/1?tweet.fields=id,author_id,created_at,lang,public_metrics')
+      stub_request(:get, 'https://api.twitter.com/labs/2/tweets/1')
         .with(
+          query: expected_request_query,
           headers:
             {
-              'Authorization'=>'Bearer token',
-              'Host'=>'api.twitter.com',
+              'Authorization' => 'Bearer token',
+              'Host' => 'api.twitter.com',
             }
         )
         .to_return(status: response_status, body: response_body)
+    end
+
+    let(:expected_request_query) do
+      {
+        'tweet.fields' => 'id,author_id,created_at,lang,public_metrics'
+      }
     end
 
     let(:response_status) { 200 }
@@ -21,7 +28,13 @@ describe TwitterLabsAPI::Resources::Tweet do
       endpoint_stub
     end
 
-    subject { client.get_tweet(id: '1') }
+    let(:request_fields) do
+      {
+        'tweet' => %w[id author_id created_at lang public_metrics]
+      }
+    end
+
+    subject { client.get_tweet(id: '1', fields: request_fields) }
 
     it 'queries the /tweets/:id endpoint' do
       subject
@@ -48,18 +61,49 @@ describe TwitterLabsAPI::Resources::Tweet do
         expect { subject }.to raise_error(TwitterLabsAPI::APIError)
       end
     end
+
+    context 'custom field request' do
+      let(:expected_request_query) do
+        {
+          'tweet.fields' => 'id,author_id,created_at,lang,public_metrics',
+          'media.fields' => 'url'
+        }
+      end
+
+      let(:request_fields) do
+        {
+          'tweet' => %w[id author_id created_at lang public_metrics],
+          'media' => %w[url]
+        }
+      end
+
+      it 'queries the /tweets/:id endpoint' do
+        subject
+  
+        expect(endpoint_stub).to have_been_requested
+      end
+    end
   end
 
   describe '#get_tweets' do
     let(:endpoint_stub) do
-      stub_request(:get, 'https://api.twitter.com/labs/2/tweets?ids=1&tweet.fields=id,author_id,created_at,lang,public_metrics').
-      with(
-        headers: {
-        'Authorization'=>'Bearer token',
-        'Host'=>'api.twitter.com',
-        })
+      stub_request(:get, 'https://api.twitter.com/labs/2/tweets?ids=1&tweet.fields=id,author_id,created_at,lang,public_metrics')
+        .with(
+          query: expected_request_query,
+          headers: {
+            'Authorization' => 'Bearer token',
+            'Host' => 'api.twitter.com'
+          }
+        )
         .to_return(status: response_status, body: response_body)
-      end
+    end
+
+    let(:expected_request_query) do
+      {
+        'ids' => '1',
+        'tweet.fields' => 'id,author_id,created_at,lang,public_metrics'
+      }
+    end
 
     let(:response_status) { 200 }
     let(:response_body) { '{"data":{}}' }
@@ -68,7 +112,13 @@ describe TwitterLabsAPI::Resources::Tweet do
       endpoint_stub
     end
 
-    subject { client.get_tweets(ids: ['1']) }
+    subject { client.get_tweets(ids: ['1'], fields: request_fields) }
+
+    let(:request_fields) do
+      {
+        'tweet' => %w[id author_id created_at lang public_metrics]
+      }
+    end
 
     it 'queries the /tweets endpoint' do
       subject
@@ -93,6 +143,28 @@ describe TwitterLabsAPI::Resources::Tweet do
 
       it 'raises an APIError' do
         expect { subject }.to raise_error(TwitterLabsAPI::APIError)
+      end
+    end
+
+    context 'custom field request' do
+      let(:expected_request_query) do
+        {
+          'tweet.fields' => 'id,author_id,created_at,lang,public_metrics',
+          'media.fields' => 'url'
+        }
+      end
+
+      let(:request_fields) do
+        {
+          'tweet' => %w[id author_id created_at lang public_metrics],
+          'media' => %w[url]
+        }
+      end
+
+      it 'queries the /tweets/:ids endpoint' do
+        subject
+
+        expect(endpoint_stub).to have_been_requested
       end
     end
   end
@@ -150,14 +222,21 @@ describe TwitterLabsAPI::Resources::Tweet do
     let(:endpoint_stub) do
       stub_request(:get, 'https://api.twitter.com/labs/2/tweets/search')
         .with(
+          query: expected_request_query,
           headers:
             {
-              'Authorization'=>'Bearer token',
-              'Host'=>'api.twitter.com',
-            },
-          query: hash_including(query: 'test')
+              'Authorization' => 'Bearer token',
+              'Host' => 'api.twitter.com'
+            }
         )
         .to_return(status: response_status, body: response_body)
+    end
+
+    let(:expected_request_query) do
+      {
+        'query' => 'test',
+        'tweet.fields' => 'id,author_id,created_at,lang,public_metrics'
+      }
     end
 
     let(:response_status) { 200 }
@@ -167,7 +246,13 @@ describe TwitterLabsAPI::Resources::Tweet do
       endpoint_stub
     end
 
-    subject { client.search(query: 'test') }
+    subject { client.search(query: 'test', fields: request_fields) }
+
+    let(:request_fields) do
+      {
+        'tweet' => %w[id author_id created_at lang public_metrics]
+      }
+    end
 
     it 'queries the /tweets/search endpoint' do
       subject
@@ -192,6 +277,29 @@ describe TwitterLabsAPI::Resources::Tweet do
 
       it 'raises an APIError' do
         expect { subject }.to raise_error(TwitterLabsAPI::APIError)
+      end
+    end
+
+    context 'custom field request' do
+      let(:expected_request_query) do
+        {
+          'query' => 'test',
+          'tweet.fields' => 'id,author_id,created_at,lang,public_metrics',
+          'media.fields' => 'url'
+        }
+      end
+
+      let(:request_fields) do
+        {
+          'tweet' => %w[id author_id created_at lang public_metrics],
+          'media' => %w[url]
+        }
+      end
+
+      it 'queries the /tweets/search endpoint' do
+        subject
+
+        expect(endpoint_stub).to have_been_requested
       end
     end
   end

--- a/spec/lib/services/params_service_spec.rb
+++ b/spec/lib/services/params_service_spec.rb
@@ -1,0 +1,15 @@
+describe ParamsService do
+  describe '#from_fields' do
+    subject { described_class.from_fields(fields) }
+    let(:fields) do
+      {
+        tweet: %w[id username],
+        media: %w[url]
+      }
+    end
+
+    it 'converts a hash of fields to query params' do
+      expect(subject).to eq({ 'tweet.fields' => 'id,username', 'media.fields' => 'url' })
+    end
+  end
+end


### PR DESCRIPTION
This improves the original implementation by allowing multiple different resource fields to be included with the response.

See this API Reference for more details:

https://developer.twitter.com/en/docs/labs/tweets-and-users/api-reference/get-tweets-id